### PR TITLE
feat: 종목 코드 또는 종목 이름으로 종목 정보 검색 기능 구현

### DIFF
--- a/core/src/main/java/com/port90/core/auth/config/SecurityConfig.java
+++ b/core/src/main/java/com/port90/core/auth/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
                                 .userService(customOAuth2UserService))
                         .successHandler(customSuccessHandler))
                 .authorizeHttpRequests(auth -> auth             // 경로별 인가 설정
-                        .requestMatchers("/", "/login", "/api/ranks/*", "/stock-charts", "/comments/**", "/error")
+                        .requestMatchers("/", "/login", "/api/ranks/*", "/stock-charts", "/stock-infos", "/comments/**", "/error")
                         .permitAll()
                         .anyRequest().authenticated())
                 .logout(logout -> logout

--- a/core/src/main/java/com/port90/core/stockinfo/application/StockInfoService.java
+++ b/core/src/main/java/com/port90/core/stockinfo/application/StockInfoService.java
@@ -1,0 +1,23 @@
+package com.port90.core.stockinfo.application;
+
+import com.port90.core.stockinfo.dto.StockInfoDto;
+import com.port90.stockdomain.infrastructure.StockInfoQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StockInfoService {
+
+    private final StockInfoQueryRepository stockInfoQueryRepository;
+
+    public List<StockInfoDto> getStockInfosByCondition(
+            String stockCode, String stockName, String cursor, int size
+    ) {
+        return stockInfoQueryRepository
+                .findStockInfosByCondition(stockCode, stockName, cursor, size)
+                .stream().map(StockInfoDto::from).toList();
+    }
+}

--- a/core/src/main/java/com/port90/core/stockinfo/dto/StockInfoDto.java
+++ b/core/src/main/java/com/port90/core/stockinfo/dto/StockInfoDto.java
@@ -1,0 +1,43 @@
+package com.port90.core.stockinfo.dto;
+
+import com.port90.stockdomain.domain.info.StockInfo;
+import com.port90.stockdomain.domain.info.StockInfoStatus;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record StockInfoDto(
+        String stockCode,
+        String stockName,
+        long stockCount, // 상장주식수
+        long marketCap, // 시가총액
+        String market, // 코스피, 코스닥
+        String stockKind, // 그룹코드
+        String stopStatus, // 거래정지여부
+        String lockStatus, // 락 구분
+
+        StockInfoStatus status,
+        LocalDate openDate,
+        LocalDate closeDate,
+
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static StockInfoDto from(StockInfo stockInfo) {
+        return new StockInfoDto(
+                stockInfo.getStockCode(),
+                stockInfo.getStockName(),
+                stockInfo.getStockCount(),
+                stockInfo.getMarketCap(),
+                stockInfo.getMarket(),
+                stockInfo.getStockKind(),
+                stockInfo.getStopStatus(),
+                stockInfo.getLockStatus(),
+                stockInfo.getStatus(),
+                stockInfo.getOpenDate(),
+                stockInfo.getCloseDate(),
+                stockInfo.getCreatedAt(),
+                stockInfo.getUpdatedAt()
+        );
+    }
+}

--- a/core/src/main/java/com/port90/core/stockinfo/presentation/StockInfoController.java
+++ b/core/src/main/java/com/port90/core/stockinfo/presentation/StockInfoController.java
@@ -1,0 +1,29 @@
+package com.port90.core.stockinfo.presentation;
+
+import com.port90.core.stockinfo.application.StockInfoService;
+import com.port90.core.stockinfo.dto.StockInfoDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/stock-infos")
+public class StockInfoController {
+
+    private final StockInfoService stockInfoService;
+
+    @GetMapping
+    public List<StockInfoDto> getStockInfosByCondition(
+            @RequestParam(required = false) String stockCode,
+            @RequestParam(required = false) String stockName,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return stockInfoService.getStockInfosByCondition(stockCode, stockName, cursor, size);
+    }
+}

--- a/stock-domain/build.gradle
+++ b/stock-domain/build.gradle
@@ -9,6 +9,12 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j:8.0.33'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // query-dsl
+    implementation "com.querydsl:querydsl-jpa:5.1.0:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 bootJar {

--- a/stock-domain/src/main/java/com/port90/stockdomain/config/QuerydslConfig.java
+++ b/stock-domain/src/main/java/com/port90/stockdomain/config/QuerydslConfig.java
@@ -1,4 +1,4 @@
-package com.port90.core.common.config;
+package com.port90.stockdomain.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;

--- a/stock-domain/src/main/java/com/port90/stockdomain/domain/info/StockInfo.java
+++ b/stock-domain/src/main/java/com/port90/stockdomain/domain/info/StockInfo.java
@@ -1,9 +1,6 @@
 package com.port90.stockdomain.domain.info;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,6 +19,7 @@ import java.time.LocalDateTime;
 public class StockInfo {
     @Id
     private String stockCode;
+    @Column(unique = true)
     private String stockName;
     private long stockCount; // 상장주식수
     private long marketCap; // 시가총액

--- a/stock-domain/src/main/java/com/port90/stockdomain/infrastructure/StockInfoQueryRepository.java
+++ b/stock-domain/src/main/java/com/port90/stockdomain/infrastructure/StockInfoQueryRepository.java
@@ -1,0 +1,39 @@
+package com.port90.stockdomain.infrastructure;
+
+import com.port90.stockdomain.domain.info.StockInfo;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.port90.stockdomain.domain.info.QStockInfo.stockInfo;
+
+@Repository
+@RequiredArgsConstructor
+public class StockInfoQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<StockInfo> findStockInfosByCondition(String stockCode, String stockName, String cursor, int size) {
+        return jpaQueryFactory
+                .selectFrom(stockInfo)
+                .where(stockCodeEq(stockCode), stockNameEq(stockName), cursorGt(cursor))
+                .orderBy(stockInfo.stockCode.asc())
+                .limit(size)
+                .fetch();
+    }
+
+    private BooleanExpression stockCodeEq(String stockCode) {
+        return stockCode != null ? stockInfo.stockCode.eq(stockCode) : null;
+    }
+
+    private BooleanExpression stockNameEq(String stockName) {
+        return stockName != null ? stockInfo.stockName.eq(stockName) : null;
+    }
+
+    private BooleanExpression cursorGt(String cursor) {
+        return cursor != null ? stockInfo.stockCode.gt(cursor) : null;
+    }
+}


### PR DESCRIPTION
변경 사항:
- stock-domain 모듈에 querydsl 의존성 추가
- core 모듈에 있던 querydsl config 클래스 stock-domain 모듈로 이동
- spring security config 미인증 경로에 /stock-infos 추가

추가된 사항:
- 종목 코드 또는 종목 이름으로 종목 정보 검색 기능 구현
- 검색 조건으로 종목 코드, 종목 이름을 받아 동적 쿼리 생성
- 종목 코드, 종목 이름 모두 null일 경우 모든 정보 반환
- 모든 정보 반환 시 stockCode를 cursor로 페이징